### PR TITLE
Error reporter is a dependency, not a dev dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "grunt-component-build": "~0.5.0",
     "grunt-mocha-phantomjs": "~0.2.8",
     "grunt-contrib-uglify": "~0.2.1",
-    "grunt-contrib-coffee": "~0.7.0",
-    "error-reporter": "~0.1.0"
+    "grunt-contrib-coffee": "~0.7.0"
   },
   "dependencies": {
+    "error-reporter": "~0.1.0"
   },
   "keywords": [],
   "scripts": {


### PR DESCRIPTION
This pull request addresses the following error when using `gom-html-parser` in another project.

``` sh
Warning: Cannot find module 'error-reporter' Use --force to continue.
```
